### PR TITLE
Update db2_rhel

### DIFF
--- a/db2_rhel
+++ b/db2_rhel
@@ -52,7 +52,7 @@ DB2_INSTALL_PATH=/opt/ibm/db2/V10.1
 
 
 list_instances() {
-  $DB2_INSTALL_PATH/bin/db2greg -dump | grep -E '^I,DB2' | \
+  $DB2_INSTALL_PATH/bin/db2greg -dump | grep -Ea '^I,DB2' | \
         cut -d, --output-delimiter=" " -s -f4,5,7
 }
 


### PR DESCRIPTION
at line 55, on RHEL 6.10  the "$DB2_INSTALL_PATH/bin/db2greg -dump | grep -E '^I,DB2'" doesn't return anything sinc the dump is a binary output. You need to add the argument -a in order to hangle the output as text.
So the line, should be:
$DB2_INSTALL_PATH/bin/db2greg -dump | grep -Ea '^I,DB2' | \